### PR TITLE
Preferred units when distance unknown

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -836,7 +836,7 @@ static void drawNodeInfo(OLEDDisplay *display, OLEDDisplayUiState *state, int16_
 
     static char distStr[20];
     if (config.display.units == meshtastic_Config_DisplayConfig_DisplayUnits_IMPERIAL) {
-        strncpy(distStr, "? mi", sizeof(distStr));
+        strncpy(distStr, "? mi", sizeof(distStr)); // might not have location data
     } else {
         strncpy(distStr, "? km", sizeof(distStr));
     }

--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -835,7 +835,11 @@ static void drawNodeInfo(OLEDDisplay *display, OLEDDisplayUiState *state, int16_
     }
 
     static char distStr[20];
-    strncpy(distStr, "? km", sizeof(distStr)); // might not have location data
+    if (config.display.units == meshtastic_Config_DisplayConfig_DisplayUnits_IMPERIAL) {
+        strncpy(distStr, "? mi", sizeof(distStr));
+    } else {
+        strncpy(distStr, "? km", sizeof(distStr));
+    }
     meshtastic_NodeInfoLite *ourNode = nodeDB.getMeshNode(nodeDB.getNodeNum());
     const char *fields[] = {username, distStr, signalStr, lastStr, NULL};
     int16_t compassX = 0, compassY = 0;


### PR DESCRIPTION
This PR correctly displays the users preferred units when the distance to a node is unknown.